### PR TITLE
Refactor cards

### DIFF
--- a/content/english/attivita/moca24.md
+++ b/content/english/attivita/moca24.md
@@ -2,9 +2,8 @@
 title: "MOCA 2024"
 subtitle: "Lo storico hacker camp italiano è Back to the r00t"
 date: 2024-09-13
+footerUrl: "https://moca.camp"
 ---
 Benvenuti al MOCA2024, un evento che celebra tre decenni di impegno, innovazione e comunità nel panorama hacker italiano.
 
 Quest'anno, dal 13 al 15 settembre, ci riuniremo per sottolineare il ruolo fondamentale delle community hacker italiane nella promozione di una cultura digitale etica, aperta e collaborativa. MOCA2024 sarà un'occasione unica per connettersi, condividere conoscenze e scoprire le ultime innovazioni nel campo della sicurezza informatica, della programmazione e del digital activism.
-
-<a href="https://moca.camp" class="bottom-2 right-2 text-accent hover:underline">Go to site >></a>

--- a/content/english/progetti/refurbish.md
+++ b/content/english/progetti/refurbish.md
@@ -2,9 +2,8 @@
 title: "Refurbish Ninja"
 subtitle: "Costruiamo un futuro migliore attraverso il recupero di rifiuti elettronici e dando lunga vita alla tecnologia"
 date: 2016-08-20
+footerUrl: "https://refurbishninja.net"
 ---
 Da questa visione nasce Refurbish Ninja: sapere, saper fare e saper essere riciclando le tecnologie per un futuro sostenibile, un progetto di innovazione sociale e di economia circolare che propone azioni di riqualificazione urbana attraverso la cultura e lo sviluppo di capacità professionali
 
 Nonostante i meccanismi consumistici e la precoce obsolescenza, crediamo che i dispositivi elettronici possano essere usati ancora a lungo prima di essere gettati via.
-
-<a href="https://refurbishninja.net" class="bottom-2 right-2 text-accent hover:underline">Go to site >></a>

--- a/content/italiano/attivita/moca24.md
+++ b/content/italiano/attivita/moca24.md
@@ -6,5 +6,3 @@ date: 2024-09-13
 Benvenuti al MOCA2024, un evento che celebra tre decenni di impegno, innovazione e comunità nel panorama hacker italiano.
 
 Quest'anno, dal 13 al 15 settembre, ci riuniremo per sottolineare il ruolo fondamentale delle community hacker italiane nella promozione di una cultura digitale etica, aperta e collaborativa. MOCA2024 sarà un'occasione unica per connettersi, condividere conoscenze e scoprire le ultime innovazioni nel campo della sicurezza informatica, della programmazione e del digital activism.
-
-<a href="https://moca.camp" class="bottom-2 right-2 text-accent hover:underline">{Vai al sito >></a>

--- a/content/italiano/progetti/refurbish.md
+++ b/content/italiano/progetti/refurbish.md
@@ -2,9 +2,8 @@
 title: "Refurbish Ninja"
 subtitle: "Costruiamo un futuro migliore attraverso il recupero di rifiuti elettronici e dando lunga vita alla tecnologia"
 date: 2016-08-20
+footerUrl: "https://refurbishninja.net"
 ---
 Da questa visione nasce Refurbish Ninja: sapere, saper fare e saper essere riciclando le tecnologie per un futuro sostenibile, un progetto di innovazione sociale e di economia circolare che propone azioni di riqualificazione urbana attraverso la cultura e lo sviluppo di capacità professionali
 
 Nonostante i meccanismi consumistici e la precoce obsolescenza, crediamo che i dispositivi elettronici possano essere usati ancora a lungo prima di essere gettati via.
-
-<a href="https://refurbishninja.net" class="bottom-2 right-2 text-accent hover:underline">Vai al sito >></a>

--- a/layouts/_default/associazione.html
+++ b/layouts/_default/associazione.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
 <article>
     <h1 class="text-4xl font-bold mb-8 text-primary-dark">{{ .Title }}</h1>
-    <div class="bg-white p-6 border-4 border-primary-dark shadow-[8px_8px_0px_0px_rgba(22,33,62,1)]">
-        {{ .Content }}
-    </div>
+    {{ partial "card.html" (dict
+        "content" .Content
+        "withShadow" true ) }}
 </article>
 
 <div class="mt-8 flex max-w-full flex-row">
@@ -31,14 +31,11 @@
 
     <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 justify-items-center lg:justify-center">
         {{ range .Site.Params.direttivo }}
-        <div
-            class="bg-white p-6 border-4 border-primary-dark shadow-[8px_8px_0px_0px_rgba(22,33,62,1)] mb-8 max-w-xs hover:shadow-lg transition-shadow duration-300">
-            <h3 class="text-2xl font-bold text-center text-primary-dark mb-2">{{ .name }} "{{ .nickname }}"</h3>
-            <p class="text-center text-accent text-sm mb-4">{{ .role }}</p>
-            <div class="mt-4 text-center">
-                <a href="mailto:{{.nickname}}@olografix.org" class="text-accent hover:underline">email</a>
-            </div>
-        </div>
+        {{ partial "card.html" (dict
+        "title" (printf "%s \"%s\"" .name .nickname)
+        "content" .role
+        "goToLink" (printf "mailto:%s@olografix.org" .nickname)
+        "goToText" "email") }}
         {{ end }}
     </section>
 </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ if .Params.externalUrl }}
+{{ if and (.Params.externalUrl) (.Params.forceRedirect | default true) }}
 <meta http-equiv="refresh" content="0; url={{ .Params.externalUrl }}" />
 {{ end }}
 
@@ -14,8 +14,10 @@
     </div>
     {{ end }}
 
-    <div class="bg-white p-6 border-4 border-primary-dark shadow-[8px_8px_0px_0px_rgba(22,33,62,1)]">
-        {{ .Content }}
-    </div>
+    {{ partial "card.html" (dict
+        "content" .Content
+        "goToLink" .Params.footerUrl
+        "goToText" (T "goExternalText")
+        "withShadow" true ) }}
 </article>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,13 +1,14 @@
 {{ define "main" }}
 
-<div class="bg-white p-6 border-4 border-primary-dark shadow-[8px_8px_0px_0px_rgba(22,33,62,1)] mb-8 relative">
-    <p class="text-accent mb-4 text-justify">{{ .Site.Params.description }}</p>
-    {{ $association := site.GetPage "section" "associazione" }}
-    <a href="{{ $association.RelPermalink | relLangURL }}" class="font-bold absolute bottom-2 right-2 text-accent hover:underline">{{ T "learnMoreText" }} >></a>
-</div>
+<!-- use custom components "card" -->
+{{ partial "card.html" (dict 
+    "content" (.Site.Params.description)
+    "goToSection" "associazione"
+    "goToText" (T "learnMoreText")
+    "withShadow" true) }}
 
 <!-- Membership Banner -->
-<div class="bg-accent text-primary-light p-4 rounded-lg mb-8">
+<div class="bg-accent text-primary-light p-4 rounded-lg mb-4 mt-4">
     <a href="https://associati.olografix.org" class="block text-center text-xl font-bold rainbow-text">
         {{ T "membershipBanner" }}
     </a>
@@ -21,20 +22,29 @@
         {{ $activitiesAndProjects := union (where .Site.RegularPages "Type" "attivita") (where .Site.RegularPages "Type" "progetti") }}
         {{ $sortedActivitiesAndProjects := sort $activitiesAndProjects ".Date" "desc" }}
         {{ range first $maxItems $sortedActivitiesAndProjects }}
-        <div class="bg-white p-4 border-2 border-primary-dark relative">
-            <h3 class="text-xl font-bold mb-2 text-accent">{{ .Title }}</h3>
-            <p class="text-accent mb-4 text-justify">{{ .Params.subtitle | default .Summary }}</p>
-            {{ if .Params.externalUrl }}
-                <a href="{{ .Params.externalUrl}}" class="text-sm font-bold absolute bottom-2 right-2 text-accent hover:underline">{{ T "goExternalText" }} >></a>
-            {{ else }}
-                <a href="{{ .RelPermalink | relLangURL }}" class="text-sm font-bold absolute bottom-2 right-2 text-accent hover:underline">{{ T "goText" }} >></a>
-            {{ end }}
-        </div>
+
+        <!-- create link and text -->
+        {{ $link := "" }}
+        {{ $text := "" }}
+        {{ if .Params.externalUrl }}
+            {{ $link = .Params.externalUrl }}
+            {{ $text = T "goExternalText" }}
+        {{ else }}
+            {{ $link = .RelPermalink | relLangURL }}
+            {{ $text = T "goText" }}
+        {{ end }}
+        <!-- use custom components "card" -->
+        {{ partial "card.html" (dict
+            "title" .Title
+            "content" (.Params.subtitle | default .Summary )
+            "goToLink" $link
+            "goToText" $text
+            "badge" (cond (eq .Type "attivita") "Attività" "Progetto" )) }}
         {{ end }}
     </div>
 
     {{ if gt (len $sortedActivitiesAndProjects) $maxItems }}
-    <div class="text-center mt-4">
+    <div class="text-center">
         <div class="grid grid-cols-2 md:grid-cols-2 gap-4">
             {{ $activities := site.GetPage "section" "attivita" }}
             <a href="{{ $activities.RelPermalink | relLangURL }}" class="inline-block bg-accent text-primary-light px-4 py-2 rounded-lg">{{ T "allActivities" }}</a>

--- a/layouts/partials/card.html
+++ b/layouts/partials/card.html
@@ -1,0 +1,32 @@
+<div class="bg-white p-6 pb-8 border-4 border-primary-dark w-full {{ if (default false .withShadow) }} shadow-[8px_8px_0px_0px_rgba(22,33,62,1)] {{ end }} mb-4 relative">
+    {{ with .title }}
+    <h3 class="text-xl font-bold mb-2 text-accent">{{ . }}</h3>
+    {{ end }}
+    <!-- content -->
+    <p class="text-accent mb-4 text-justify">{{ .content }}</p>
+
+    <!-- footer -->
+    {{ if or (.goToSection) (.goToLink) (.badge) }}
+    <div class="absolute bottom-0 left-0 right-0 bg-gray-100 px-6 py-1 flex items-center justify-between">
+        <!-- badge -->
+        {{ with .badge }}
+        <span class="badge">
+            {{ . }}
+        </span>
+        {{ else }}
+        <span></span>
+        {{ end }}
+        <!-- link href generation, `.goToSection` or `.goToLink` are acceptable but not together -->
+        {{ if or (.goToSection) (.goToLink) }}
+            {{ $link := "" }}
+            {{ if .goToSection }}
+                {{ $section := site.GetPage "section" .goToSection }}
+                {{ $link = ($section.RelPermalink | relLangURL) }}
+            {{ else if .goToLink }}
+                {{ $link = .goToLink }}
+            {{ end }}
+            <a href="{{ $link }}" class="text-sm text-accent hover:underline ml-auto">{{ .goToText }} >></a>
+        {{ end }}
+      </div>
+      {{ end }}
+</div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -85,3 +85,7 @@ body {
 .rainbow-text:hover {
   animation-play-state: running;
 }
+
+.badge {
+  font-size: 12px; background-color: white; border: 1px solid #666666; border-radius: 4px; padding: 2px 8px; box-shadow: 1px 1px 0px rgba(0,0,0,0.2);
+}


### PR DESCRIPTION
Visto che le card sparse per il sito stavano diventando ingestibili, ho creato un componente `card` che è riutilizzabile e parametrizzabile.

Accetta in input:
- `title`: titolo della card
- `content`: contenuto della card
- `goToLink` oppure `goToSection`:
    - `goToLink` genera un link verso un sito esterno con `target="_blank"`
    - `goToSection` genera automaticamente un link interno verso un contenuto `content/` che esiste
- `goToText`: il testo del link, è possibile usare il multilingua (`(T chiave)`)
- `badge`: genera un badge nel footer della card, a sinistra
- `withShadow`: ombreggiatura pazzeska