### PR TITLE
new event mo twang l'aquila

### DIFF
--- a/content/english/attivita/mo-twang-aq.md
+++ b/content/english/attivita/mo-twang-aq.md
@@ -1,0 +1,52 @@
+---
+title: "MO_Twang: DIY Arcade Game Workshop"
+subtitle: "A two-day practical workshop dedicated to the design and self-construction of an interactive arcade game that combines electronics, programming, and recycled materials. Two days of electronics, programming, and free digital culture."
+date: "2025-12-13T15:00:00"
+endDate: "2025-12-14T15:00:00"
+recurring: false
+location: "Spazio Praxis - Via Veneziani, 4 - L'Aquila"
+locationUrl: "https://www.openstreetmap.org/node/12301862132"
+---
+
+#### **Description**
+
+A two-day practical workshop dedicated to the design and self-construction of an interactive arcade game that combines electronics, programming, and recycled materials.
+
+We will build a physical game together using low-cost electronic components and easily available reclaimed materials. Participants will work in groups to assemble, program, and customize the game.
+
+**Program:**
+
+**Day 1 (Saturday, December 13, 3:00 PM-6:00 PM) - A bit of theory and design**
+- Basic electronics: programmable boards, LEDs, sensors
+- Thinking like a hacker: transforming common objects into technological components
+- Design with reclaimed materials (boxes, containers, PVC pipes)
+- First practical trials and component testing
+
+**Day 2 (Sunday, December 14, 3:00 PM-6:00 PM) - Construction and game time**
+- Construction of the physical structure using recycled materials
+- Electronic assembly and wiring
+- Collaborative debugging
+- Final tournament: everyone plays together!
+
+**Who can participate:**
+
+Open to **30 people** without distinction of age (approximately 15 years old and up) or background. No prior skills are needed: the approach is inclusive and values everyone's contribution.
+
+**What to bring:**
+
+Nothing! All materials (electronic components, reclaimed materials, tools) are provided by Metro Olografix.
+
+**Why participate:**
+
+- Learn electronics and programming by doing
+- Build with inexpensive materials against waste
+- Create accessible sociality and community
+- Take home DIY construction skills
+
+**Cost:**
+
+Free participation. To register [sign up here](https://cryptpad.fr/form/#/2/form/view/MBtHBHw-JJkqNq5VteFj7TFV5su9YviRi80wlcnI+QI/)
+
+---
+
+*Project carried out in collaboration with the **Comitato Soci Coop Etruria L'Aquila**.*

--- a/content/italiano/attivita/mo-twang-aq.md
+++ b/content/italiano/attivita/mo-twang-aq.md
@@ -1,0 +1,52 @@
+---
+title: "MO_Twang: Workshop di autocostruzione di un gioco arcade"
+subtitle: "Workshop pratico di due giorni dedicato alla progettazione e autocostruzione di un gioco arcade interattivo che unisce elettronica, programmazione e materiali di riuso. Due giorni di elettronica, programmazione e cultura digitale libera."
+date: "2025-12-13T15:00:00"
+endDate: "2025-12-14T15:00:00"
+recurring: false
+location: "Spazio Praxis - Via Veneziani, 4 - L'Aquila"
+locationUrl: "https://www.openstreetmap.org/node/12301862132"
+---
+
+#### **Descrizione**
+
+Workshop pratico di due giorni dedicato alla progettazione e autocostruzione di un gioco arcade interattivo che unisce elettronica, programmazione e materiali di riuso.
+
+Costruiremo insieme un gioco fisico utilizzando componenti elettronici a basso costo e materiali di recupero facilmente reperibili. I partecipanti lavoreranno in gruppo per assemblare, programmare e personalizzare il gioco.
+
+**Programma:**
+
+**Giorno 1 (Sabato 13 Dicembre, ore 15:00-18:00) - Un po' di teoria e progettazione**
+- Elettronica di base: schede programmabili, LED, sensori
+- Pensare da hacker: trasformare oggetti comuni in componenti tecnologici
+- Progettazione con materiali di recupero (scatole, contenitori, tubi PVC)
+- Prime prove pratiche e test componenti
+
+**Giorno 2 (Domenica 14 Dicembre, ore 15:00-18:00) - Costruzione e gioco**
+- Costruzione della struttura fisica con materiali di riuso
+- Assemblaggio elettronico e cablaggio
+- Debugging collaborativo
+- Torneo finale: tutti giocano insieme!
+
+**Chi può partecipare:**
+
+Aperto a **30 persone** senza distinzione di età (indicativamente dai 15 anni in su) o preparazione. Non servono competenze pregresse: l'approccio è inclusivo e valorizza il contributo di tutte le persone.
+
+**Cosa portare:**
+
+Niente! Tutti i materiali (componenti elettronici, materiali di recupero, attrezzature) sono forniti da Metro Olografix.
+
+**Perché partecipare:**
+
+- Imparare elettronica e programmazione facendo
+- Costruire con materiali poveri contro lo spreco
+- Creare socialità e aggregazione accessibile
+- Portare a casa competenze di autocostruzione
+
+**Costo:**
+
+Partecipazione gratuita. Per iscriverti [registrati qui](https://cryptpad.fr/form/#/2/form/view/MBtHBHw-JJkqNq5VteFj7TFV5su9YviRi80wlcnI+QI/)
+
+---
+
+*Progetto realizzato in collaborazione con il **Comitato Soci Coop Etruria L'Aquila**.*

--- a/content/spanish/attivita/mo-twang-aq.md
+++ b/content/spanish/attivita/mo-twang-aq.md
@@ -1,0 +1,52 @@
+---
+title: "MO_Twang: Taller de Autoconstrucción de un Juego Arcade"
+subtitle: "Taller práctico de dos días dedicado al diseño y autoconstrucción de un juego arcade interactivo que combina electrónica, programación y materiales de reutilización. Dos días de electrónica, programación y cultura digital libre."
+date: "2025-12-13T15:00:00"
+endDate: "2025-12-14T15:00:00"
+recurring: false
+location: "Spazio Praxis - Via Veneziani, 4 - L'Aquila"
+locationUrl: "https://www.openstreetmap.org/node/12301862132"
+---
+
+#### **Descripción**
+
+Taller práctico de dos días dedicado al diseño y autoconstrucción de un juego arcade interactivo que combina electrónica, programación y materiales de reutilización.
+
+Construiremos juntos un juego físico utilizando componentes electrónicos de bajo costo y materiales de recuperación fácilmente disponibles. Los participantes trabajarán en grupo para ensamblar, programar y personalizar el juego.
+
+**Programa:**
+
+**Día 1 (Sábado 13 de Diciembre, 15:00-18:00) - Un poco de teoría y diseño**
+- Electrónica básica: placas programables, LED, sensores
+- Pensar como un hacker: transformar objetos comunes en componentes tecnológicos
+- Diseño con materiales de recuperación (cajas, contenedores, tubos de PVC)
+- Primeras pruebas prácticas y test de componentes
+
+**Día 2 (Domingo 14 de Diciembre, 15:00-18:00) - Construcción y juego**
+- Construcción de la estructura física con materiales de reutilización
+- Ensamblaje electrónico y cableado
+- Depuración colaborativa
+- Torneo final: ¡todos juegan juntos!
+
+**Quién puede participar:**
+
+Abierto a **30 personas** sin distinción de edad (aproximadamente de 15 años en adelante) o preparación. No se necesitan habilidades previas: el enfoque es inclusivo y valora la contribución de todas las personas.
+
+**Qué traer:**
+
+¡Nada! Todos los materiales (componentes electrónicos, materiales de recuperación, herramientas) son proporcionados por Metro Olografix.
+
+**Por qué participar:**
+
+- Aprender electrónica y programación haciendo
+- Construir con materiales sencillos contra el despilfarro
+- Crear socialización y agregación accesible
+- Llevar a casa habilidades de autoconstrucción
+
+**Costo:**
+
+Participación gratuita. Para inscribirse [regístrese aquí](https://cryptpad.fr/form/#/2/form/view/MBtHBHw-JJkqNq5VteFj7TFV5su9YviRi80wlcnI+QI/)
+
+---
+
+*Proyecto realizado en colaboración con el **Comitato Soci Coop Etruria L'Aquila**.*


### PR DESCRIPTION
abbiamo aggiunto la descrizione del workshop su twang a l'aquila. essendo (credo) il primo evento multigiorno pubblicato sul sito, come endDate è stato impostato il giorno e l'ora di inizio del secondo incontro, che visivamene risulta venire meglio e più comprensibile dalle masse.