### PR TITLE
Aggiornato pageRef URL per 'Associati' nei menù in tutte le lingue

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -33,7 +33,7 @@
     weight = 5
 [[main]]
     name = "Join us"
-    url = "/associazione/associati"
+    pageRef = "/associazione/associati/"
     weight = 6
 [[main]]
     name = "Shop"

--- a/config/_default/menus.es.toml
+++ b/config/_default/menus.es.toml
@@ -33,7 +33,7 @@
     weight = 5
 [[main]]
     name = "Asociate"
-    url = "/associazione/associati"
+    pageRef = "/associazione/associati/"
     weight = 6
 [[main]]
     name = "Shop"

--- a/config/_default/menus.it.toml
+++ b/config/_default/menus.it.toml
@@ -33,7 +33,7 @@
     weight = 5
 [[main]]
     name = "Associati"
-    url = "/associazione/associati"
+    pageRef = "/associazione/associati/"
     weight = 6
 [[main]]
     name = "Shop"


### PR DESCRIPTION
Ho modificato il campo per l'elemento "Associati" dell'header da "url" a "pageRef" in modo che il link venga correttamente risolto per tutte le versioni IT/EN/ES 