### PR TITLE
fix: reso stabile l’ordine dei pulsanti lingua in header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,7 +34,7 @@ defaultContentLanguageInSubdir = false
     languageName = 'ES'
     title = 'Metro Olografix'
     contentDir = "content/spanish"
-    weight = 2
+    weight = 3
     [languages.es.permalinks]
       progetti = "projects/:slug"
       attivita = "activities/:slug"


### PR DESCRIPTION
Imposta un weight distinto per ES (da 2 a 3) così lo switch lingua non cambia ordine tra pagine. Ad esempio nella Home l'ordine è EN | ES, nell'attività ES | EN.