### PR TITLE
design: Corkboard Bulletin pass on homepage, cards & shop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ public/
 !scripts/*
 node_modules/
 static/images/og/
+
+# Impeccable transient tooling artifacts (session hook cache + dated critique reports)
+.impeccable/hook.cache.json
+.impeccable/critique/

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-12T17:31:01Z",
+  "title": "Design System: Metro Olografix",
+  "extensions": {
+    "colorMeta": {
+      "deep-circuit": { "role": "primary", "displayName": "Deep Circuit", "canonical": "#16213e", "tonalRamp": ["#0a0f1c", "#111830", "#16213e", "#22304f", "#37507d", "#5d78a6", "#9fb2cf", "#dbe3ef"] },
+      "deep-circuit-accent": { "role": "primary", "displayName": "Deep Circuit Accent", "canonical": "#042a59", "tonalRamp": ["#02152d", "#031f43", "#042a59", "#0a3f7f", "#155ba8", "#3d82cf", "#7fb0e6", "#cfe1f6"] },
+      "signal-green": { "role": "secondary", "displayName": "Signal Green", "canonical": "#10b981", "tonalRamp": ["#052e21", "#064e33", "#059669", "#10b981", "#34d399", "#6ee7b7", "#a7f3d0", "#d1fae5"] },
+      "spark-pink": { "role": "tertiary", "displayName": "Spark Pink", "canonical": "#e94560", "tonalRamp": ["#3d0f18", "#6b1a2b", "#9c2740", "#c73351", "#e94560", "#f27488", "#f8a5b2", "#fcd6dd"] },
+      "spark-amber": { "role": "tertiary", "displayName": "Spark Amber", "canonical": "#fca311", "tonalRamp": ["#4a2f01", "#7a4f02", "#a86d05", "#d18b0a", "#fca311", "#fdbb4d", "#fed488", "#feecc4"] },
+      "board-indigo": { "role": "neutral", "displayName": "Board Indigo", "canonical": "#eef2ff", "tonalRamp": ["#1a1f3a", "#2b3568", "#404e97", "#5f6fc0", "#8f9bd8", "#b9c1e8", "#d7ddf5", "#eef2ff"] },
+      "prose-ink": { "role": "neutral", "displayName": "Prose Ink", "canonical": "#333333", "tonalRamp": ["#000000", "#1a1a1a", "#333333", "#4d4d4d", "#666666", "#8c8c8c", "#bfbfbf", "#f0f0f0"] }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display / Wordmark", "purpose": "The 'Metro Olografix_' wordmark with blinking cursor. One per page." },
+      "headline": { "displayName": "Section Headline", "purpose": "Section headers, often prefixed with // as a code comment." },
+      "title": { "displayName": "Card Title", "purpose": "Event, project, and space names on cards. Deep Circuit Accent." },
+      "body": { "displayName": "Body", "purpose": "Card content and long-form prose. 65-75ch measure." },
+      "label": { "displayName": "Label / Meta", "purpose": "Badges, dates, recurrence and location metadata." }
+    },
+    "shadows": [
+      { "name": "pinned-card", "value": "8px 8px 0px 0px rgba(22,33,62,1)", "purpose": "Signature neobrutalist hard offset shadow on featured cards. Zero blur, Deep Circuit color." },
+      { "name": "stamped-badge", "value": "1px 1px 0px rgba(0,0,0,0.2)", "purpose": "Tiny hard shadow giving badges a stamped, tactile lift." }
+    ],
+    "motion": [
+      { "name": "state-standard", "value": "0.3s ease-in-out", "purpose": "Default for hover/color/transform state changes (logo scale, link color, status badge)." },
+      { "name": "blink", "value": "blink 2s step-end infinite", "purpose": "The wordmark cursor. Must be disabled under prefers-reduced-motion." },
+      { "name": "rainbow", "value": "rainbow-text 3s infinite", "purpose": "Playful pink -> amber -> white cycle on wordmark/menu hover only." }
+    ],
+    "breakpoints": [
+      { "name": "md", "value": "768px" },
+      { "name": "max-content", "value": "max-w-5xl (64rem)" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Pinned Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "The signature bulletin card: thick Deep Circuit frame, sharp corners, optional hard offset shadow.",
+      "html": "<div class=\"ds-card\"><h3 class=\"ds-card-title\">// workshop arduino</h3><p class=\"ds-card-body\">Un pomeriggio per costruire il tuo primo circuito. Porta le mani, i componenti ce li mettiamo noi.</p><div class=\"ds-card-foot\"><span class=\"ds-badge ds-badge-upcoming\">in arrivo</span><a class=\"ds-card-link\" href=\"#\">vai &gt;&gt;</a></div></div>",
+      "css": ".ds-card { background: #ffffff; border: 4px solid #16213e; box-shadow: 8px 8px 0px 0px rgba(22,33,62,1); padding: 16px; font-family: 'IBM Plex Mono', ui-monospace, monospace; color: #333333; display: flex; flex-direction: column; gap: 12px; max-width: 380px; } .ds-card-title { color: #042a59; font-weight: 700; font-size: 1.25rem; margin: 0; } .ds-card-body { font-size: 1rem; line-height: 1.6; margin: 0; } .ds-card-foot { display: flex; align-items: center; justify-content: space-between; background: #f3f4f6; margin: 4px -16px -16px; padding: 6px 16px; } .ds-card-link { color: #042a59; font-size: 0.875rem; text-decoration: none; } .ds-card-link:hover { text-decoration: underline; }"
+    },
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Full-width navigational CTA (all activities / all projects, membership banner).",
+      "html": "<a class=\"ds-btn-primary\" href=\"#\">tutte le attività</a>",
+      "css": ".ds-btn-primary { display: inline-block; background: #042a59; color: #e2e8f0; font-family: 'IBM Plex Mono', ui-monospace, monospace; padding: 8px 16px; border-radius: 8px; text-decoration: none; text-align: center; transition: background 0.3s ease-in-out; } .ds-btn-primary:hover { background: #16213e; } .ds-btn-primary:focus-visible { outline: 2px solid #fca311; outline-offset: 2px; }"
+    },
+    {
+      "name": "Event CTA Button",
+      "kind": "button",
+      "refersTo": "button-event",
+      "description": "The 'come to this event' action, tinted with live-green meaning.",
+      "html": "<a class=\"ds-btn-event\" href=\"#\">scopri di più →</a>",
+      "css": ".ds-btn-event { display: inline-block; background: #059669; color: #ffffff; font-family: 'IBM Plex Mono', ui-monospace, monospace; padding: 8px 16px; border-radius: 8px; text-decoration: none; transition: background 0.3s ease-in-out; } .ds-btn-event:hover { background: #047857; } .ds-btn-event:focus-visible { outline: 2px solid #16213e; outline-offset: 2px; }"
+    },
+    {
+      "name": "Upcoming Badge",
+      "kind": "chip",
+      "refersTo": "badge-upcoming",
+      "description": "Green 'live/upcoming' badge stamped onto a card footer.",
+      "html": "<span class=\"ds-badge ds-badge-upcoming\">in arrivo</span>",
+      "css": ".ds-badge { font-family: 'IBM Plex Mono', ui-monospace, monospace; font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 4px; box-shadow: 1px 1px 0px rgba(0,0,0,0.2); } .ds-badge-upcoming { background: #10b981; color: #ffffff; border: 1px solid #059669; }"
+    },
+    {
+      "name": "Nav Bar",
+      "kind": "nav",
+      "refersTo": null,
+      "description": "Desktop Deep Circuit top bar with white links and the it/en/es language switch.",
+      "html": "<nav class=\"ds-nav\"><div class=\"ds-nav-links\"><a href=\"#\" class=\"ds-nav-link ds-active\">associazione</a><a href=\"#\" class=\"ds-nav-link\">attività</a><a href=\"#\" class=\"ds-nav-link\">progetti</a></div><div class=\"ds-nav-lang\"><a href=\"#\">IT</a><a href=\"#\">EN</a><a href=\"#\">ES</a></div></nav>",
+      "css": ".ds-nav { display: flex; justify-content: space-between; align-items: center; background: #16213e; padding: 8px 16px; font-family: 'IBM Plex Mono', ui-monospace, monospace; } .ds-nav-links { display: flex; gap: 16px; } .ds-nav-link { color: #ffffff; text-decoration: none; transition: color 0.2s; } .ds-nav-link:hover { text-decoration: underline; } .ds-nav-link.ds-active { font-weight: 700; } .ds-nav-lang { display: flex; gap: 12px; color: #ffffff; } .ds-nav-lang a { color: #ffffff; text-decoration: none; }"
+    },
+    {
+      "name": "Wordmark",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "The 'Metro Olografix_' wordmark with a blinking terminal cursor.",
+      "html": "<span class=\"ds-wordmark\">Metro Olografix<span class=\"ds-cursor\">_</span></span>",
+      "css": ".ds-wordmark { font-family: 'IBM Plex Mono', ui-monospace, monospace; font-weight: 700; font-size: clamp(1.5rem, 4vw, 3rem); color: #16213e; } .ds-cursor { display: inline-block; animation: ds-blink 2s step-end infinite; } @keyframes ds-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } } @media (prefers-reduced-motion: reduce) { .ds-cursor { animation: none; } }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Corkboard Bulletin",
+    "overview": "Metro Olografix looks like a community noticeboard run by hackers: hard-edged cards pinned to a wall, events and projects tacked up where anyone can read them, everything typed in the same honest monospace. It is terminal-native — IBM Plex Mono end to end, a blinking cursor after the wordmark, // comment prefixes on section headers — but the terminal here is a door held open, not a gate. The signature move is the frame: cards wear a thick 4px Deep Circuit border and a hard 8px offset shadow with no blur, a deliberate paper-cutout weight that reads as tactile and confident. Nothing is glassy, nothing gradients, nothing apologizes for being built by hand.",
+    "keyCharacteristics": [
+      "Monospace everything — IBM Plex Mono is the single voice, weighted for hierarchy.",
+      "Hard neobrutalist frames — border-4 + blurless 8px offset shadow, sharp corners.",
+      "Terminal grammar — blinking cursor, // comment headers, >> link affordances.",
+      "Deep Circuit navy on a soft indigo board, with green as the 'it's live / it's open' signal.",
+      "Handmade over slick — seasonal, playful, unmistakably built by the collective."
+    ],
+    "rules": [
+      { "name": "The Board-Not-Cream Rule", "body": "The background is cool Board Indigo, never a warm cream/sand/paper tint. Warmth in this brand comes from voice and seasonal flourishes, never from a beige surface.", "section": "colors" },
+      { "name": "The Green-Means-Live Rule", "body": "Green is the signal that something is real and happening now — upcoming events, open spaces, active membership. Never spend it on decoration; its meaning is the point.", "section": "colors" },
+      { "name": "The One-Voice Rule", "body": "IBM Plex Mono is the only typeface. Never introduce a second family for contrast — contrast comes from weight (400 to 700) and size.", "section": "typography" },
+      { "name": "The Comment-Header Rule", "body": "Section headings may lead with // as a deliberate code-comment gesture. It's a brand system, not a decorative eyebrow — use it as structure, never as a tracked all-caps kicker above every block.", "section": "typography" },
+      { "name": "The No-Blur Rule", "body": "Shadows never blur. Every shadow is a hard offset (0px blur) in a solid color. If it looks like it's floating on a cloud, it's wrong; it should look pinned to a board.", "section": "elevation" },
+      { "name": "The Frame-First Rule", "body": "Elevation always pairs with a real border (border-4 Deep Circuit). The shadow is the border's cast, not a standalone glow.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do frame cards with 4px Deep Circuit borders and sharp 0 corners — the hard edge is the brand.",
+      "Do use the blurless 8px 8px 0 rgba(22,33,62,1) offset shadow for featured cards, and only ever hard, un-blurred shadows.",
+      "Do keep IBM Plex Mono as the single voice; build hierarchy with weight (400 to 700) and size.",
+      "Do spend Signal Green only on things that are genuinely live — upcoming events, open sedi, active membership.",
+      "Do keep the it/en/es switch obvious, consistent, and equivalent on every page; language access is core here.",
+      "Do honor prefers-reduced-motion for the blink cursor, hover rainbow, and any seasonal effect.",
+      "Do hold WCAG AA contrast — bump muted grays toward Prose Ink if body text on white is even close."
+    ],
+    "donts": [
+      "Don't ship the corporate SaaS/startup look — no gradient heroes, no soft blurred shadows, no interchangeable rounded icon-card grids, no empower/supercharge/next-generation copy.",
+      "Don't drift sterile-institutional — nothing gray, bureaucratic, or public-office lifeless.",
+      "Don't slide into the generic AI landing page — no cream/sand/paper background, no tiny tracked uppercase eyebrows above every section, no identical repeated card grids.",
+      "Don't overdesign — effects never win over usability; the terminal personality is texture, not spectacle.",
+      "Don't use gradient text, decorative glassmorphism, or side-stripe border-left accents. Emphasis comes from weight, the frame, and green.",
+      "Don't round card corners or blur a shadow — that instantly reads as the SaaS surface this system rejects.",
+      "Don't add a second typeface. If it isn't IBM Plex Mono, it doesn't belong."
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+Guidance for agents working in this repository.
+
+## Design Context
+
+This is the official site of **Metro Olografix**, a hacker / free-digital-culture association founded in 1994 (Pescara + L'Aquila). It's a Hugo static site, trilingual (it/en/es), source in `layouts/` + `static/css`, built output in `public/`.
+
+- **Register:** brand (identity/content site — design is the product). **Platform:** web.
+- **Strategy:** a community hub before a funnel. Serve curious newcomers and active regulars on the same page. Underground yet welcoming, with 30 years of roots. Primary CTA: come to an event in person; secondary: browse activities/projects.
+- **Visual system — "The Corkboard Bulletin":** terminal-native neobrutalism. IBM Plex Mono only, hard `border-4` Deep Circuit (`#16213e`/`#042a59`) frames with blurless `8px 8px 0` offset shadows, sharp corners, `//` comment headers, blinking cursor. Cool Board Indigo (`#eef2ff`) background — never cream. Signal Green (`#10b981`) means "live." Honor `prefers-reduced-motion`; hold WCAG AA.
+- **Anti-references:** corporate SaaS/startup, sterile-institutional, generic AI landing, overdesigned/flashy.
+
+See **[PRODUCT.md](PRODUCT.md)** for strategy and **[DESIGN.md](DESIGN.md)** for the full token spec before designing or editing UI.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,221 @@
+---
+name: Metro Olografix
+description: The Corkboard Bulletin — a terminal-native, neobrutalist community board for a 30-year hacker collective.
+colors:
+  deep-circuit: "#16213e"
+  deep-circuit-accent: "#042a59"
+  pale-slate: "#e2e8f0"
+  board-indigo: "#eef2ff"
+  card-white: "#ffffff"
+  prose-ink: "#333333"
+  signal-green: "#10b981"
+  signal-green-deep: "#059669"
+  alert-red: "#dc2626"
+  spark-pink: "#e94560"
+  spark-amber: "#fca311"
+  muted-line: "#666666"
+  code-mist: "#f1f5f9"
+typography:
+  display:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "clamp(1.5rem, 4vw, 3rem)"
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: "normal"
+  headline:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "1.875rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "normal"
+  title:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "1.25rem"
+    fontWeight: 700
+    lineHeight: 1.3
+    letterSpacing: "normal"
+  body:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+  label:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "0.75rem"
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: "normal"
+rounded:
+  none: "0"
+  sm: "4px"
+  md: "8px"
+  full: "9999px"
+spacing:
+  sm: "8px"
+  md: "16px"
+  lg: "32px"
+components:
+  card:
+    backgroundColor: "{colors.card-white}"
+    textColor: "{colors.prose-ink}"
+    typography: "{typography.body}"
+    rounded: "{rounded.none}"
+    padding: "16px"
+  card-title:
+    textColor: "{colors.deep-circuit-accent}"
+    typography: "{typography.title}"
+  button-primary:
+    backgroundColor: "{colors.deep-circuit-accent}"
+    textColor: "{colors.pale-slate}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  button-event:
+    backgroundColor: "{colors.signal-green-deep}"
+    textColor: "{colors.card-white}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  badge:
+    backgroundColor: "{colors.card-white}"
+    textColor: "{colors.prose-ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "2px 8px"
+  badge-upcoming:
+    backgroundColor: "{colors.signal-green}"
+    textColor: "{colors.card-white}"
+    typography: "{typography.label}"
+    rounded: "{rounded.sm}"
+    padding: "2px 8px"
+---
+
+# Design System: Metro Olografix
+
+## 1. Overview
+
+**Creative North Star: "The Corkboard Bulletin"**
+
+Metro Olografix looks like a community noticeboard run by hackers: hard-edged cards pinned to a wall, events and projects tacked up where anyone can read them, everything typed in the same honest monospace. It is terminal-native — IBM Plex Mono end to end, a blinking `_` cursor after the wordmark, `//` comment prefixes on section headers — but the terminal here is a door held open, not a gate. The system's job is to make a living, 30-year-old collective feel *present*: real dates, real spaces, real people, stamped onto the page with weight.
+
+The signature move is the frame. Cards wear a thick `4px` Deep Circuit border and a hard `8px 8px` offset shadow with no blur — a deliberate paper-cutout weight that reads as tactile and confident, a bulletin pinned up rather than a soft SaaS surface floating in space. Nothing is glassy, nothing gradients, nothing apologizes for being built by hand. Seasonal flourishes (the December Christmas-lights string, the membership "shop effect") are welcome precisely because they're handmade and a little irreverent — the underground voice showing through.
+
+This system explicitly rejects the corporate SaaS/startup look (no gradient heroes, no interchangeable rounded icon-cards, no stock "team collaborating" photography), the sterile-institutional register (nothing gray, bureaucratic, or public-office lifeless), the generic AI landing page (no cream backgrounds, no tracked eyebrows, no identical repeated card grids), and the overdesigned/flashy trap (effects never win over usability). The mono is heritage, not costume — this is a literal hacker association, so the terminal register is earned.
+
+**Key Characteristics:**
+- Monospace everything — IBM Plex Mono is the single voice, weighted for hierarchy.
+- Hard neobrutalist frames — `border-4` + blurless `8px` offset shadow, sharp corners.
+- Terminal grammar — blinking cursor, `//` comment headers, `>>` link affordances.
+- Deep Circuit navy on a soft indigo board, with green as the "it's live / it's open" signal.
+- Handmade over slick — seasonal, playful, unmistakably built by the collective.
+
+## 2. Colors
+
+A restrained, high-contrast palette: one deep navy carries structure, green signals life, and a two-note spark pair adds hacker mischief on hover.
+
+### Primary
+- **Deep Circuit** (#16213e): The structural navy. Card borders, the desktop header bar, section headings, prose emphasis. This is the ink the whole board is drawn with.
+- **Deep Circuit Accent** (#042a59): The slightly bluer sibling used for interactive ink — links, card titles, primary buttons, the "visit / go" affordances. Where Deep Circuit is structure, this is action.
+
+### Secondary
+- **Signal Green** (#10b981) and **Signal Green Deep** (#059669): The "it's happening" color. Upcoming-event badges, the highlighted next-event panel, the primary event CTA, the sede "open now" status dot. Green means real, live, and go.
+
+### Tertiary
+- **Spark Pink** (#e94560) and **Spark Amber** (#fca311): The rainbow-hover pair. Reserved for playful moments — the animated wordmark/menu hover cycling pink → amber → white. Personality, never structure.
+
+### Neutral
+- **Board Indigo** (#eef2ff): The page background (Tailwind `indigo-50`). The soft board that everything is pinned to — cool, quiet, never cream.
+- **Card White** (#ffffff): The surface of every pinned card.
+- **Prose Ink** (#333333): Body copy on white.
+- **Muted Line** (#666666): Badge outlines, hairline dividers, secondary meta text.
+- **Code Mist** (#f1f5f9): Inline `code` background and table zebra.
+- **Alert Red** (#dc2626): Reserved strictly for the sede "closed" status. Never decorative.
+
+### Named Rules
+**The Board-Not-Cream Rule.** The background is cool Board Indigo, never a warm cream/sand/paper tint. Warmth in this brand comes from voice and seasonal flourishes, never from a beige surface.
+
+**The Green-Means-Live Rule.** Green is the signal that something is real and happening now — upcoming events, open spaces, active membership. Never spend it on decoration; its meaning is the point.
+
+## 3. Typography
+
+**Display Font:** IBM Plex Mono (fallback `ui-monospace, monospace`)
+**Body Font:** IBM Plex Mono (same family)
+**Label/Mono Font:** IBM Plex Mono (same family)
+
+**Character:** One family, many weights. The whole system speaks in a single monospace voice and builds hierarchy through weight and size alone — the honest, evenly-spaced cadence of a terminal or a typewritten bulletin. Chosen deliberately as heritage for a real hacker collective, not as a shorthand for "technical."
+
+### Hierarchy
+- **Display** (700, `clamp(1.5rem, 4vw, 3rem)`, line-height 1.1): The "Metro Olografix_" wordmark with its blinking cursor. One per page, top-left.
+- **Headline** (700, 1.875rem / `text-3xl`): Section headers, often prefixed `//` as a code-comment (`// Le nostre sedi`). The primary way the page is chunked.
+- **Title** (700, 1.25rem / `text-xl`, Deep Circuit Accent): Card titles — the name of an event, project, or space.
+- **Body** (400, 1rem, line-height 1.6, Prose Ink): Card content and long-form prose. Cap measure at 65–75ch in prose contexts.
+- **Label** (600, 0.75rem): Badges, dates, recurrence and location meta. Short strings only.
+
+### Named Rules
+**The One-Voice Rule.** IBM Plex Mono is the only typeface. Never introduce a second family for "contrast" — contrast comes from weight (400 → 700) and size. A proportional font anywhere breaks the terminal.
+
+**The Comment-Header Rule.** Section headings may lead with `//` as a deliberate code-comment gesture. It's a brand system, not a decorative eyebrow — use it as structure, never as a tracked all-caps kicker above every block.
+
+## 4. Elevation
+
+Flat surface, hard shadow. This system has no ambient/blurred elevation. Depth is expressed by a single neobrutalist device: a thick border plus a blurless, offset drop shadow that reads as a physical cutout pinned to the board. Shadows are structural and decorative-by-identity, never soft ambience.
+
+### Shadow Vocabulary
+- **Pinned Card** (`box-shadow: 8px 8px 0px 0px rgba(22,33,62,1)`): The signature. A hard Deep Circuit shadow offset down-right with zero blur. Applied to feature cards (`withShadow: true`). The whole neobrutalist identity lives here.
+- **Stamped Badge** (`box-shadow: 1px 1px 0px rgba(0,0,0,0.2)`): A tiny hard shadow giving badges a stamped, tactile lift.
+
+### Named Rules
+**The No-Blur Rule.** Shadows never blur. Every shadow is a hard offset (`0px` blur) in a solid color. A soft, blurred, low-opacity shadow is the SaaS look this system rejects — if it looks like it's floating on a cloud, it's wrong; it should look pinned to a board.
+
+**The Frame-First Rule.** Elevation always pairs with a real border (`border-4` Deep Circuit). The shadow is the border's cast, not a standalone glow.
+
+## 5. Components
+
+### Buttons
+- **Shape:** Softly rounded (`8px` / `rounded-lg`) — the one place corners relax, so tap targets read as pressable.
+- **Primary:** Deep Circuit Accent background, Pale Slate text, `8px 16px` padding. Used for "all activities / all projects" and the membership banner. Often full-width and centered.
+- **Event CTA:** Signal Green Deep background, white text — the "come to this event" action, tinted with the live-green meaning.
+- **Hover / Focus:** Color deepens on hover (`hover:bg-green-700` etc.); links underline. All state changes stay within a `~0.2–0.3s` ease. Ensure a visible `:focus-visible` ring for keyboard users.
+
+### Badges
+- **Style:** Card White background, `1px` Muted Line border, `4px` radius, Stamped-Badge shadow, `12px` label type.
+- **State:** Default (neutral, e.g. "past") vs **Upcoming** — Signal Green fill, white text, green border. Green badge = live.
+
+### Cards / Containers (signature)
+- **Corner Style:** Sharp (`0` radius). Corners are never rounded on cards — the hard edge is the identity.
+- **Background:** Card White on the Board Indigo page.
+- **Border:** `4px` solid Deep Circuit. Non-negotiable; the frame defines the card.
+- **Shadow Strategy:** Optional Pinned-Card hard offset shadow (see Elevation) for featured cards; list cards may sit flat inside a grid.
+- **Internal Padding:** `16px` (`p-4`). Footer strip (badge + `link >>`) sits on a `gray-100` band, flush to the frame.
+
+### Inputs / Fields
+No native form system ships today (the site is content-first). When inputs are added: `2px` Deep Circuit stroke, sharp corners, Card White fill, a hard `focus` shift (border thickens / offset shadow appears) rather than a soft glow — consistent with the No-Blur Rule.
+
+### Navigation
+- **Desktop:** A full-width Deep Circuit bar. White links, `hover:underline`, active link bold. Dropdowns open on hover as bordered Deep Circuit panels. Social icons + it/en/es language switch sit at the right, always visible and equivalent per page.
+- **Mobile:** Bar collapses to a menu-image button that opens the menu partial.
+- **Wordmark:** "Metro Olografix" with a blinking `_` cursor; hover triggers the rainbow (Spark Pink → Amber → white) cycle.
+
+### Signature: the Highlighted Next Event
+A Signal-Green-framed panel (`border-2` green, `green-50` fill) that surfaces the single nearest upcoming activity with a large day/month/year stamp. This is the primary-CTA engine — it makes "come to an event" impossible to miss.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** frame cards with `4px` Deep Circuit borders and sharp `0` corners — the hard edge is the brand.
+- **Do** use the blurless `8px 8px 0 rgba(22,33,62,1)` offset shadow for featured cards, and only ever hard, un-blurred shadows.
+- **Do** keep IBM Plex Mono as the single voice; build hierarchy with weight (400→700) and size.
+- **Do** spend Signal Green only on things that are genuinely live — upcoming events, open sedi, active membership.
+- **Do** keep the it/en/es switch obvious, consistent, and equivalent on every page; language access is core here.
+- **Do** honor `prefers-reduced-motion` for the blink cursor, hover rainbow, and any seasonal effect (the Christmas lights already do).
+- **Do** hold WCAG AA contrast — bump muted grays toward Prose Ink if body text on white is even close.
+
+### Don't:
+- **Don't** ship the corporate SaaS/startup look — no gradient heroes, no soft blurred shadows, no interchangeable rounded icon-card grids, no "empower/supercharge/next-generation" copy.
+- **Don't** drift sterile-institutional — nothing gray, bureaucratic, or public-office lifeless.
+- **Don't** slide into the generic AI landing page — no cream/sand/paper background, no tiny tracked uppercase eyebrows above every section, no identical repeated card grids.
+- **Don't** overdesign — effects never win over usability; the terminal personality is texture, not spectacle.
+- **Don't** use gradient text (`background-clip: text`), decorative glassmorphism, or side-stripe `border-left` accents. Emphasis comes from weight, the frame, and green.
+- **Don't** round card corners or blur a shadow — that instantly reads as the SaaS surface this system rejects.
+- **Don't** add a second typeface. If it isn't IBM Plex Mono, it doesn't belong.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,49 @@
+# Product
+
+## Register
+
+brand
+
+## Platform
+
+web
+
+## Users
+
+Two audiences share every page. **Curious newcomers** arrive knowing little — they've heard the name, found a workshop, or stumbled in — and are quietly deciding whether this place is for them and whether they'd be welcome. **Active members and regulars** already orbit the collective and return to check what's on, when, and where: upcoming activities, project updates, the state of the two spaces. The site is primarily Italian (default language) with full English and Spanish parallels, so language switching is a real part of the audience's experience, not an afterthought. The job to be done splits cleanly: newcomers need to understand what Metro Olografix *is* and how to show up in person; regulars need fast, reliable logistics and a sense of continuity.
+
+## Product Purpose
+
+Metro Olografix is a hacker and free-digital-culture association founded in 1994 in Pescara, now running physical spaces in both Pescara and L'Aquila. This is its official home on the web. Its job is to be the reliable community hub — surfacing workshops, talks, events, projects, the photogallery, membership, and everything about the physical sedi — rather than a persuasion funnel. Success is a site that a regular trusts for "what's happening and where," and that a newcomer reads as a living, active, welcoming community they could genuinely walk into. Utility and belonging come before conversion.
+
+## Positioning
+
+Metro Olografix is a real, three-decade-old hacker community with spaces you can physically walk into — not an online brand, not a defunct archive. Every screen should reinforce that this is a living collective with a door that's actually open.
+
+## Conversion & proof
+
+- **Primary CTA:** come to an event in person — a workshop, talk, or open evening. Physical presence is the true conversion; the calendar and activity surfaces should always make the nearest real thing easy to find and act on.
+- **Secondary CTA:** browse activities and projects — for visitors not ready to show up, the softer step is exploring what the association actually does, past and upcoming, to build a feel before committing.
+- **The line a visitor remembers after 10 seconds:** "There's a real hacker community near me that I can actually go to."
+- **Belief ladder** (synthesized from the strategic interview; refine as needed): (1) this is real and still active, not a dead site; (2) it's for someone like me — I'd be welcome, not gatekept; (3) something specific is happening that I could attend; (4) I know exactly where and when to show up.
+- **Proof on hand:** founded 1994 (30+ years of continuity), two active physical spaces (Pescara, L'Aquila), an ongoing stream of workshops and events, a photogallery of past gatherings, and a publicly named direttivo. No testimonials or press assets have been supplied yet; drop any into `.impeccable/assets/proof/` to put them to use.
+
+## Brand Personality
+
+Three words: **underground, welcoming, enduring.** The voice is playful hacker wit — the terminal register the site already speaks in (blinking cursor, `//` comment-style headers, monospace throughout) — but the mischief never tips into gatekeeping; the door is always open. It is plainspoken and free of marketing gloss, proud of a long history without stiffening into a nostalgia museum. Emotionally the site should make a visitor feel they belong, feel curious enough to come see for themselves, and trust that these are real people who know their scene.
+
+## Anti-references
+
+Not a corporate SaaS/startup: no gradient hero, no interchangeable rounded icon-cards, no stock "team collaborating" photography, no empower/supercharge/next-generation copy. Not sterile-institutional: nothing bureaucratic, gray, or public-office lifeless. Not a generic AI landing page: no cream-and-tracked-eyebrow 2026 template look, no identical repeated card grids. Not overdesigned or flashy: effects never win over usability; the terminal personality is texture, not spectacle.
+
+## Design Principles
+
+- **Community hub before funnel.** Serve the regular checking a date and the newcomer sizing up the vibe on the same page. Utility and belonging outrank persuasion.
+- **Underground, door open.** Keep the insider hacker voice, but let it invite rather than exclude. Wit that welcomes, never wit that tests.
+- **Show the living collective.** Prove vitality through real activity — actual events, real spaces, named people, photos — not through claims or slogans.
+- **Earned identity, never costume.** The monospace/terminal aesthetic is authentic heritage for a literal hacker collective; preserve and sharpen it, and never let it decay into generic-technical decoration.
+- **Roots on display.** Thirty years and two physical sedi are the credibility. Make continuity and place visible rather than hiding them behind a homepage.
+
+## Accessibility & Inclusion
+
+Hold a solid WCAG 2.1 AA baseline: sufficient text contrast, full keyboard navigation with visible focus states, meaningful alt text, and semantic HTML. Because the interface carries persistent terminal motion (the blinking cursor, hover animations), that motion must stay within AA expectations as new effects are added. Treat multilingual clarity as an accessibility concern in its own right: the it/en/es switch must remain obvious, consistent, and equivalent across every page, since language access is central to this audience.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -21,6 +21,7 @@ laquilaDescription = "<p>Come and visit us at our space in <strong>Via Ed Arco C
 hqGotoMap = "Map"
 visitSpace = "Come visit!"
 nextUpcomingEvent = "Next Upcoming Event"
+noUpcomingActivities = "No events scheduled at the moment — but we meet at the space every week. Come by."
 
 dateLabel = "Date"
 recurrenceLabel = "Recurrence"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -21,6 +21,7 @@ laquilaDescription = "<p>Ven a visitarnos en nuestra sede en <strong>Via Ed Arco
 hqGotoMap = "Mapa"
 visitSpace = "¡Ven a visitarnos!"
 nextUpcomingEvent = "Proximo Evento"
+noUpcomingActivities = "Ningún evento programado por ahora — pero nos vemos en la sede cada semana. Pásate a vernos."
 
 dateLabel = "Dia"
 recurrenceLabel = "Recurrencia"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -21,6 +21,7 @@ laquilaDescription = "<p>Vieni a trovarci nella nostra sede in <strong>Via Ed Ar
 hqGotoMap = "Mappa"
 visitSpace = "Vieni a trovarci!"
 nextUpcomingEvent = "Prossimo Evento"
+noUpcomingActivities = "Nessun evento in programma al momento — ma ci vediamo in sede ogni settimana. Passa a trovarci."
 
 dateLabel = "Data"
 recurrenceLabel = "Ricorrenza"

--- a/layouts/_default/associazione.html
+++ b/layouts/_default/associazione.html
@@ -27,7 +27,7 @@
 </div>
 
 <article>
-    <h1 class="text-4xl font-bold mb-8 text-primary-dark">{{ T "boardText" }}</h1>
+    <h2 class="text-4xl font-bold mb-8 text-primary-dark">{{ T "boardText" }}</h2>
 
     <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 justify-items-center lg:justify-center">
         {{ $boardMembers := .Site.Params.direttivo }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -94,7 +94,7 @@
   <link href="/css/lightbox.min.css" rel="stylesheet" />
   <script src="/js/lightbox-plus-jquery.min.js"></script>
   {{end}}
-  {{ if eq .Site.Params.enableShopEffect true }}
+  {{ if partial "is-lights-season.html" . }}
   <link rel="stylesheet" href="/css/shop.css" />
   {{ end }}
   <link rel="stylesheet" href="/css/fontawesome.css" />

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
 {{ end }}
 
 <article>
-    <h1 class="text-4xl font-bold mb-2 text-primary-dark">{{ .Title }}</h1>
+    <h1 class="text-4xl font-bold mb-2 text-primary-dark break-words text-balance">{{ .Title }}</h1>
     <h2 class="text-xl mb-4 text-primary-dark">{{ .Params.subtitle }}</h2>
 
     {{ if .Params.hasTOC | default false}}

--- a/layouts/attivita/single.html
+++ b/layouts/attivita/single.html
@@ -5,7 +5,7 @@
 {{ end }}
 
 <article>
-    <h1 class="text-4xl font-bold mb-2 text-primary-dark">{{ .Title }}</h1>
+    <h1 class="text-4xl font-bold mb-2 text-primary-dark break-words text-balance">{{ .Title }}</h1>
     
     {{ with .Params.subtitle }}
     <h2 class="text-xl mb-4 text-primary-dark">{{ . }}</h2>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,15 +1,98 @@
 {{ define "main" }}
 
-<!-- Intro — full width -->
-<div class="mb-8">
+<!-- Compute the nearest upcoming activity once; it drives the hero -->
+{{ $now := now }}
+{{ $activities := where .Site.RegularPages "Type" "attivita" }}
+{{ $activities = $activities | intersect .Site.AllPages }}
+{{ $upcomingActivities := where $activities "Date" "ge" $now }}
+{{ $upcomingActivities = sort $upcomingActivities ".Date" "asc" }}
+
+<!-- ================================================================= -->
+<!-- HERO — when an event is coming up, it leads. Otherwise identity   -->
+<!-- leads (the intro card below) and this section is skipped entirely -->
+<!-- ================================================================= -->
+{{ if gt (len $upcomingActivities) 0 }}
+{{ $ev := index $upcomingActivities 0 }}
+<section class="mt-2 mb-10">
+
+    <!-- resolve link (external overrides internal) -->
+    {{ $link := $ev.RelPermalink | relLangURL }}
+    {{ $external := false }}
+    {{ with $ev.Params.externalUrl }}{{ $link = . }}{{ $external = true }}{{ end }}
+
+    <article
+        class="bg-white border-4 border-primary-dark shadow-[8px_8px_0px_0px_rgba(22,33,62,1)] p-6 md:p-8">
+        <!-- live signal: // header + blinking green dot -->
+        <div class="flex items-center gap-2 mb-5">
+            <span class="text-sm font-bold uppercase tracking-wide text-primary-dark">// {{ T "nextUpcomingEvent" }}</span>
+            <span class="w-2.5 h-2.5 rounded-full bg-[#059669] blink" role="img"
+                aria-label="{{ T "hqStatusOpen" }}"></span>
+        </div>
+
+        <div class="flex flex-col md:flex-row md:items-stretch gap-6 md:gap-8">
+            <!-- date stamp: green day number = the live signal -->
+            <div
+                class="flex md:flex-col items-baseline md:items-start gap-3 md:gap-1 md:justify-center md:w-40 md:pr-6 shrink-0">
+                <span class="text-6xl md:text-7xl font-bold leading-none text-[#059669]">{{ $ev.Date.Format "02" }}</span>
+                <span class="flex flex-col leading-tight">
+                    <span class="text-xl font-bold uppercase text-primary-dark">{{ time.Format "January" $ev.Date }}</span>
+                    <span class="text-lg text-gray-700">{{ $ev.Date.Format "2006" }}</span>
+                </span>
+            </div>
+
+            <!-- details -->
+            <div class="flex-grow flex flex-col">
+                <h2 class="text-2xl md:text-4xl font-bold text-accent mb-3 text-balance break-words">{{ $ev.Title }}</h2>
+
+                {{ $startTime := $ev.Date.Format "15:04" }}
+                {{ if ne $startTime "00:00" }}
+                <div class="flex items-center mb-2 text-gray-700">
+                    <i class="far fa-clock mr-2 text-primary-dark" aria-hidden="true"></i>
+                    <span>{{ $startTime }}</span>
+                    {{ with $ev.Params.endDate }}
+                    {{ $endTime := (time.AsTime .).Format "15:04" }}
+                    {{ if ne $endTime "00:00" }}<span class="mx-2">–</span><span>{{ $endTime }}</span>{{ end }}
+                    {{ end }}
+                </div>
+                {{ end }}
+
+                {{ with $ev.Params.location }}
+                <div class="flex items-center mb-3 text-gray-700">
+                    <i class="fas fa-map-marker-alt mr-2 text-primary-dark" aria-hidden="true"></i>
+                    {{ if $ev.Params.locationUrl }}
+                    <a href="{{ $ev.Params.locationUrl }}" target="_blank" rel="noopener"
+                        class="text-accent hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-dark">{{ . }}</a>
+                    {{ else }}
+                    <span>{{ . }}</span>
+                    {{ end }}
+                </div>
+                {{ end }}
+
+                <p class="text-gray-700 mb-6 flex-grow">{{ $ev.Params.subtitle | default $ev.Summary }}</p>
+
+                <div>
+                    <a href="{{ $link }}" {{ if $external }}target="_blank" rel="noopener noreferrer"{{ end }}
+                        class="inline-block bg-accent hover:bg-primary-dark text-primary-light font-bold px-6 py-3 rounded-md transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-dark">
+                        {{ T "learnMoreText" }} →
+                    </a>
+                </div>
+            </div>
+        </div>
+    </article>
+</section>
+{{ end }}
+
+<!-- Intro — who we are. Leads the page (with weight) when no event is queued;
+     sits quietly under the event hero when one is. -->
+<div class="mb-8 {{ if gt (len $upcomingActivities) 0 }}mt-0{{ else }}mt-2{{ end }}">
     {{ partial "card.html" (dict
     "content" (.Site.Params.description)
     "goToSection" "associazione"
     "goToText" (T "learnMoreText")
-    "withShadow" true) }}
+    "withShadow" (eq (len $upcomingActivities) 0)) }}
 </div>
 
-<!-- Le nostre sedi — 2-up grid -->
+<!-- Le nostre sedi — 2-up grid (proof of life) -->
 <div class="mb-8">
     <div class="flex items-baseline gap-3 mb-4">
         <h2 class="text-3xl font-bold text-primary-dark font-mono">// {{ T "sediHeader" }}</h2>
@@ -31,137 +114,31 @@
     </div>
 </div>
 
-<!-- Get upcoming activities to highlight the nearest one -->
-{{ $now := now }}
-{{ $activities := where .Site.RegularPages "Type" "attivita" }}
-{{ $activities = $activities | intersect .Site.AllPages }}
-{{ $upcomingActivities := where $activities "Date" "ge" $now }}
-{{ $upcomingActivities := sort $upcomingActivities ".Date" "asc" }}
-
-<!-- Check if we have any upcoming activities to highlight -->
-{{ if gt (len $upcomingActivities) 0 }}
-<!-- Extract the nearest upcoming activity -->
-{{ $highlightedActivity := index $upcomingActivities 0 }}
-
-<!-- Create the highlighted activity card -->
-<div class="mt-8 bg-green-50 border-2 border-green-500 p-4 shadow-md">
-    <h2 class="text-2xl font-bold mb-2 text-green-700">{{ T "nextUpcomingEvent" | default "Upcoming Event" }}</h2>
-    <div class="flex flex-col md:flex-row gap-6">
-        <div class="md:w-2/3">
-            <h3 class="text-xl font-bold text-green-800 mb-2">{{ $highlightedActivity.Title }}</h3>
-
-            {{ $startTime := $highlightedActivity.Date.Format "15:04" }}
-            {{ $endTime := "00:00" }}
-
-            {{ with $highlightedActivity.Params.endDate }}
-            {{ $endTime = (time.AsTime .).Format "15:04" }}
-            {{ end }}
-
-            {{ if or (ne $startTime "00:00") (ne $endTime "00:00") }}
-            <div class="flex items-center mb-3 text-gray-700">
-                <i class="far fa-clock mr-2 text-green-600"></i>
-
-                {{ if ne $startTime "00:00" }}
-                <span>{{ $startTime }}</span>
-                {{ end }}
-
-                {{ with $highlightedActivity.Params.endDate }}
-                <span class="mx-2">-</span>
-
-                {{ $formattedEndTime := (time.AsTime .).Format "15:04" }}
-                {{ if ne $formattedEndTime "00:00" }}
-                <span>{{ $formattedEndTime }}</span>
-                {{ end }}
-                {{ end }}
-            </div>
-            {{ end }}
-
-            {{ with $highlightedActivity.Params.location }}
-            <div class="flex items-center mb-3 text-gray-700">
-                <i class="fas fa-map-marker-alt mr-2 text-green-600"></i>
-                {{ if $highlightedActivity.Params.locationUrl }}
-                <a href="{{ $highlightedActivity.Params.locationUrl }}" target="_blank" rel="noopener"
-                    class="hover:underline text-accent">{{ . }}</a>
-                {{ else }}
-                <span>{{ . }}</span>
-                {{ end }}
-            </div>
-            {{ end }}
-
-            <p class="mb-4 text-gray-700">{{ $highlightedActivity.Params.subtitle | default $highlightedActivity.Summary
-                }}</p>
-
-            <!-- Generate link URL -->
-            {{ $link := "" }}
-            {{ if $highlightedActivity.Params.externalUrl }}
-            {{ $link = $highlightedActivity.Params.externalUrl }}
-            {{ else }}
-            {{ $link = $highlightedActivity.RelPermalink | relLangURL }}
-            {{ end }}
-
-            <a href="{{ $link }}"
-                class="inline-block bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors">
-                {{ T "learnMoreText" }} →
-            </a>
-        </div>
-        <div class="md:w-1/3 flex items-center justify-center">
-            <div class="text-center">
-                <div class="text-5xl font-bold text-green-700 mb-2">
-                    {{ $highlightedActivity.Date.Format "02" }}
-                </div>
-                <div class="text-xl text-green-600 uppercase">
-                    {{ time.AsTime $highlightedActivity.Date | time.Format "January" }}
-                </div>
-                <div class="text-lg text-green-600">
-                    {{ $highlightedActivity.Date.Format "2006" }}
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-{{ end }}
-
-<!-- Membership Banner -->
-<div class="bg-accent text-primary-light p-4 rounded-lg mb-4 mt-4">
-    {{ $associati := .Site.GetPage "/associazione/associati" }}
-    <a href="{{ $associati.RelPermalink | relLangURL }}" class="block text-center text-xl font-bold">
-        {{ T "membershipBanner" }}
-    </a>
-</div>
-
-{{ partial "shop.html" . }}
-
+<!-- Attività + Progetti -->
 <section class="mb-8">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8 relative">
         <!-- Activities Column -->
         <div class="flex flex-col">
             <h2 class="text-3xl font-bold mb-4 text-primary-dark">{{ T "activitiesHeader" }}</h2>
 
-            {{ $now := now }}
-            {{ $activities := where .Site.RegularPages "Type" "attivita" }}
-            {{ $activities = $activities | intersect .Site.AllPages }}
-
-            <!-- Split upcoming and past events -->
-            {{ $upcomingActivities := where $activities "Date" "ge" $now }}
-            {{ $pastActivities := where $activities "Date" "lt" $now }}
-
-            <!-- Sort upcoming activities by date (ascending - nearest first) -->
-            {{ $upcomingActivities := sort $upcomingActivities ".Date" "asc" }}
-            <!-- Sort past activities by date (descending - most recent first) -->
-            {{ $pastActivities := sort $pastActivities ".Date" "desc" }}
-
-            <!-- Create a final sorted list where upcoming ALWAYS come first -->
-            {{ $displayActivities := slice }}
-            {{ $displayActivities = $upcomingActivities }}
-            {{ if lt (len $displayActivities) 4 }}
-            {{ $displayActivities = $displayActivities | append (first (sub 4 (len $displayActivities)) $pastActivities)
-            }}
+            {{ if eq (len $upcomingActivities) 0 }}
+            <p class="text-sm text-gray-700 mb-4">{{ T "noUpcomingActivities" }}</p>
             {{ end }}
 
-            <!-- Skip the highlighted activity if there's one -->
+            <!-- Split upcoming and past events -->
+            {{ $pastActivities := where $activities "Date" "lt" $now }}
+            {{ $pastActivities := sort $pastActivities ".Date" "desc" }}
+
+            <!-- Upcoming always first, backfill with past -->
+            {{ $displayActivities := $upcomingActivities }}
+            {{ if lt (len $displayActivities) 4 }}
+            {{ $displayActivities = $displayActivities | append (first (sub 4 (len $displayActivities)) $pastActivities) }}
+            {{ end }}
+
+            <!-- Skip the event already featured in the hero -->
             {{ if gt (len $upcomingActivities) 0 }}
-            {{ $highlightedActivity := index $upcomingActivities 0 }}
-            {{ $displayActivities = where $displayActivities "Permalink" "ne" $highlightedActivity.Permalink }}
+            {{ $heroActivity := index $upcomingActivities 0 }}
+            {{ $displayActivities = where $displayActivities "Permalink" "ne" $heroActivity.Permalink }}
             {{ end }}
 
             <div class="grid grid-rows-2 gap-4 flex-grow">
@@ -192,18 +169,18 @@
                 "locationUrl" .Params.locationUrl
                 "goToLink" $link
                 "goToText" $text
-                "badge" (cond $upcoming (T "comingEvent") "")
+                "badge" (cond $upcoming (T "comingEvent") (T "pastEvents"))
                 "isExternal" $external
                 "fullHeight" true
                 "withShadow" false) }}
                 {{ end }}
             </div>
 
-            {{ $activities := site.GetPage "section" "attivita" }}
+            {{ $activitiesSection := site.GetPage "section" "attivita" }}
             <div class="mt-4">
-                <a href="{{ $activities.RelPermalink | relLangURL }}"
-                    class="inline-block bg-accent text-primary-light px-4 py-2 rounded-lg w-full text-center">{{ T
-                    "allActivities" }}</a>
+                <a href="{{ $activitiesSection.RelPermalink | relLangURL }}"
+                    class="inline-block w-full text-center px-4 py-2 rounded-md border-2 border-primary-dark text-primary-dark font-bold hover:bg-primary-dark hover:text-white transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-dark">{{
+                    T "allActivities" }}</a>
             </div>
         </div>
 
@@ -241,14 +218,25 @@
                 {{ end }}
             </div>
 
-            {{ $projects := site.GetPage "section" "progetti" }}
+            {{ $projectsSection := site.GetPage "section" "progetti" }}
             <div class="mt-4">
-                <a href="{{ $projects.RelPermalink | relLangURL }}"
-                    class="inline-block bg-accent text-primary-light px-4 py-2 rounded-lg w-full text-center">{{ T
-                    "allProjects" }}</a>
+                <a href="{{ $projectsSection.RelPermalink | relLangURL }}"
+                    class="inline-block w-full text-center px-4 py-2 rounded-md border-2 border-primary-dark text-primary-dark font-bold hover:bg-primary-dark hover:text-white transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-dark">{{
+                    T "allProjects" }}</a>
             </div>
         </div>
     </div>
 </section>
+
+<!-- Membership — present but demoted below the event + activities -->
+<div class="bg-accent text-primary-light px-4 py-2.5 mb-8">
+    {{ $associati := .Site.GetPage "/associazione/associati" }}
+    <a href="{{ $associati.RelPermalink | relLangURL }}"
+        class="block text-center text-base md:text-lg font-bold hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-light">
+        {{ T "membershipBanner" }}
+    </a>
+</div>
+
+{{ partial "shop.html" . }}
 
 {{ end }}

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,6 +1,14 @@
-{{ with .Parent }}
-
-    {{ partial "breadcrumbs.html" . }}
-    {{ if .Parent }}►{{ end }}
-    <a href="{{ .Permalink }}">{{ .Title }}</a>
+{{ if .Parent }}
+<nav aria-label="Breadcrumb" class="text-sm text-gray-600 font-mono mb-4">
+    <ol class="flex flex-wrap items-center gap-x-2 gap-y-1">
+        {{ range .Ancestors.Reverse }}
+        <li class="flex items-center gap-2">
+            <a href="{{ .RelPermalink }}" {{ if .IsHome }}aria-label="Home"{{ end }}
+                class="text-accent hover:underline">{{ if .IsHome }}~{{ else }}{{ .Title }}{{ end }}</a>
+            <span aria-hidden="true" class="text-gray-400">/</span>
+        </li>
+        {{ end }}
+        <li class="font-bold text-primary-dark truncate max-w-[70vw] md:max-w-none" aria-current="page">{{ .Title }}</li>
+    </ol>
+</nav>
 {{ end }}

--- a/layouts/partials/card.html
+++ b/layouts/partials/card.html
@@ -5,7 +5,7 @@
     <!-- main content -->
     <div class="{{ if $showFooter }}flex-grow{{ end }}">
         {{ with .title }}
-        <h3 class="text-xl font-bold mb-2 text-accent">{{ . | safeHTML }}</h3>
+        <h3 class="text-xl font-bold mb-2 text-accent break-words">{{ . | safeHTML }}</h3>
         {{ end }}
 
         <!-- date and recurrence info if provided -->
@@ -14,7 +14,7 @@
             {{ with .date }}
             <div class="flex items-center mb-1">
                 <i class="far fa-calendar-alt mr-2"></i>
-                <span>{{ dateFormat "02 Jan 2006" . }}</span>
+                <span>{{ time.Format "02 Jan 2006" . }}</span>
                 <!-- Show time if it's not 00:00 -->
                 {{ if ne (dateFormat "15:04" .) "00:00" }}
                 <span class="mx-2">{{ dateFormat "15:04" . }}</span>
@@ -22,7 +22,7 @@
 
                 {{ with $.endDate }}
                 <span class="mx-2">-</span>
-                <span>{{ dateFormat "02 Jan 2006" . }}</span>
+                <span>{{ time.Format "02 Jan 2006" . }}</span>
                 <!-- Show end time if it's not 00:00 -->
                 {{ if ne (dateFormat "15:04" .) "00:00" }}
                 <span class="mx-2">{{ dateFormat "15:04" . }}</span>
@@ -68,7 +68,7 @@
         {{ end }}
 
         <!-- content -->
-        <div class="prose text-justify">{{ .content | safeHTML }}</div>
+        <div class="prose">{{ .content | safeHTML }}</div>
     </div>
 
     <!-- footer -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -88,10 +88,16 @@
               class="h-full w-auto object-contain max-w-none" />
           </a>
         </div>
-        <a href="{{ .Site.BaseURL | relLangURL }}">
+        <a href="{{ .Site.BaseURL | relLangURL }}" aria-label="Metro Olografix — home">
+          {{ if .IsHome }}
           <h1 class="text-2xl md:text-5xl font-bold m-0 transition-all duration-300">
-            Metro Olografix<span class="inline-block blink">_</span>
+            Metro Olografix<span class="inline-block blink" aria-hidden="true">_</span>
           </h1>
+          {{ else }}
+          <p class="text-2xl md:text-5xl font-bold m-0 transition-all duration-300">
+            Metro Olografix<span class="inline-block blink" aria-hidden="true">_</span>
+          </p>
+          {{ end }}
         </a>
       </div>
     </div>

--- a/layouts/partials/is-lights-season.html
+++ b/layouts/partials/is-lights-season.html
@@ -1,0 +1,15 @@
+{{- /*
+  Single source of truth for the seasonal Christmas-lights effect.
+  Returns "true" (truthy in Hugo) only when BOTH hold:
+    1. the master switch `enableShopEffect` is on, and
+    2. today falls in the holiday window: 1 Dec – 6 Jan (through the Epiphany / Befana).
+  Returns "" (falsy) otherwise, so the shop card ships plain off-season.
+
+  This is evaluated at build time. The site rebuilds daily via GitHub Actions
+  (cron '0 0 * * *', TZ Europe/Rome), so the effect turns on/off at the right
+  date within 24h without anyone flipping a flag.
+*/ -}}
+{{- $m := int (now.Format "1") -}}
+{{- $d := int (now.Format "2") -}}
+{{- $inSeason := or (eq $m 12) (and (eq $m 1) (le $d 6)) -}}
+{{- if and .Site.Params.enableShopEffect $inSeason -}}true{{- end -}}

--- a/layouts/partials/shop.html
+++ b/layouts/partials/shop.html
@@ -1,6 +1,7 @@
 <!-- Shop Promotion Section -->
 <section class="mt-8 mb-8">
     <div class="christmas-lights-wrapper">
+        {{ if partial "is-lights-season.html" . }}
         <div class="christmas-lights">
             <!-- Top lights -->
             <div class="christmas-light red" style="left: 3%; top: 0; animation-delay: 0s;"></div>
@@ -67,6 +68,7 @@
             <div class="christmas-light red" style="right: 0; top: 89%; animation-delay: 0.4s; transform: rotate(90deg);"></div>
             <div class="christmas-light green" style="right: 0; top: 95%; animation-delay: 0.9s; transform: rotate(90deg);"></div>
         </div>
+        {{ end }}
 
         {{ partial "card.html" (dict
             "title" (T "shopHeader")

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -224,3 +224,32 @@ body {
 .recurring-event .loading {
   animation: pulse 1.5s infinite ease-in-out;
 }
+
+/* ---- Keyboard focus (AA): visible ring on every interactive element ---- */
+/* :where() keeps specificity at 0 so per-element Tailwind utilities still win. */
+:where(a, button, summary, [tabindex]:not([tabindex="-1"])):focus-visible {
+  outline: 2px solid #16213e;
+  outline-offset: 2px;
+}
+
+/* On the dark surfaces (header bar, mobile menu, footer) flip the ring to light. */
+.bg-primary-dark a:focus-visible,
+.bg-primary-dark button:focus-visible,
+footer a:focus-visible,
+footer button:focus-visible {
+  outline-color: #e2e8f0;
+}
+
+/* ---- Respect reduced-motion: stop the terminal animations (blink, rainbow,
+   letter flip, pulse, seasonal lights) and make transitions instant. ---- */
+@media (prefers-reduced-motion: reduce) {
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/static/css/shop.css
+++ b/static/css/shop.css
@@ -70,3 +70,12 @@
         animation: none;
     }
 }
+
+/* On small screens the 60+ absolutely-positioned bulbs crowd and overlap the
+   card (and the side columns can bleed past the viewport edge). They're a
+   desktop flourish, so drop them on mobile and keep the plain shop card. */
+@media (max-width: 640px) {
+    .christmas-lights {
+        display: none;
+    }
+}


### PR DESCRIPTION
Applies the **Corkboard Bulletin** design system (terminal-native neobrutalism, IBM Plex Mono, hard `border-4` frames + blurless offset shadows, Signal Green = "live") across the site's key layouts, plus a11y and structural hardening.

## Homepage
- Lead with the **upcoming event as a card-system hero** when one exists.
- When there are **no events**, lead with identity instead of an aggressive empty state, noting the weekly in-person meetups.
- **Green = live signal only** (dot + date number); primary CTA uses Deep Circuit accent to hold WCAG AA contrast.
- Membership demoted to a slim strip; secondary buttons converted to ghost.

## Accessibility & structure
- Exactly **one `h1` per page** (wordmark `h1` only on home; Direttivo `h1` → `h2`).
- **Semantic breadcrumbs** (`nav`/`ol`, `aria-current`, Home landmark) with mobile truncation.
- Global `:focus-visible` outlines with a dark-surface override; honors `prefers-reduced-motion`.
- Localized month names via `time.Format`; `break-words`/`text-balance` on long titles.

## Shop / seasonal
- Christmas-lights effect gated behind `is-lights-season.html` — single source of truth (`enableShopEffect` + Dec 1 – Jan 6 window), evaluated at build time and correct within 24h thanks to the daily cron rebuild. Shop card ships plain off-season; lights hidden on mobile.

## Typography
- Dropped justified text in card prose (monospace rivers).

## Docs
- Adds `PRODUCT.md`, `DESIGN.md`, `CLAUDE.md`, and the `design.json` sidecar documenting the system. Transient Impeccable tooling artifacts are gitignored.

Verified with a clean `hugo` build.